### PR TITLE
Fix compile errors

### DIFF
--- a/09_appendices.tex
+++ b/09_appendices.tex
@@ -71,4 +71,4 @@ Media and Information Processing (DMIP 2023)\\
 Submitted: June 30, 2023\\
 Accepted: September 1, 2023\\
 
-\includepdf[pages={1-6}, fitpaper=true]{papers/WSSE2023_W4057_combined_v2.pdf}
+\includepdf[pages={1-2}, fitpaper=true]{pdfs/example.pdf}

--- a/09_appendices.tex
+++ b/09_appendices.tex
@@ -71,4 +71,4 @@ Media and Information Processing (DMIP 2023)\\
 Submitted: June 30, 2023\\
 Accepted: September 1, 2023\\
 
-\includepdf[pages={1-2}, fitpaper=true]{pdfs/example.pdf}
+% \includepdf[pages={1-2}, fitpaper=true]{pdfs/example.pdf}

--- a/main.tex
+++ b/main.tex
@@ -22,7 +22,7 @@
  \usepackage{listings}
  \usepackage{hyperref}
  \usepackage{svg}
- \usepackage{subfig}
+% \usepackage{subfig}
 \usepackage{pdflscape}
 \usepackage{pdfpages}
 \usepackage{booktabs}


### PR DESCRIPTION
I just want to propose a couple of fixes to the template that fixes most of the compile errors for the current version of the template. Please note that I tested this in Overleaf as an easy entry point to Latex. After these fixes, the template will be left with some warnings (labels, hbox, etc.) that easily goes away as the user edits the file.

# Undefined Control Sequence at line 70.
To fix this, we can comment out line 25 `\usepackage{subfig}`

Reference: https://tex.stackexchange.com/questions/213273/undefined-control-sequence-at-begindocument

# `\includepdf` errors.
To fix this, comment out the `\includepdf` call in the appendices tex file. Our gitignore file excludes pdf files so we can't provide an example pdf to reference.

If the user needs it, they can:
Upload a PDF corresponding to the PDF referenced in the appendices tex file (i.e. pdfs/example.pdf, which needs to have at least 2 pages). 